### PR TITLE
Add Merchant's items view page

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -30,6 +30,11 @@ class MerchantsController < ApplicationController
     redirect_to '/merchants'
   end
 
+  def items
+    merchant = Merchant.find(params[:merchant_id])
+    @merchant_items = merchant.items
+  end
+
   private
 
   def merchant_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,4 +6,5 @@
     <p>Price: <%= "$#{item.price}" %></p>
     <p>Status: <%= item.status %></p>
     <p>Inventory: <%= item.inventory %></p>
+    <p>Merchant: <%= link_to "#{item.merchant.name}", "/merchants/#{item.merchant.id}"%></p>
 <% end %>

--- a/app/views/merchants/items.html.erb
+++ b/app/views/merchants/items.html.erb
@@ -1,0 +1,8 @@
+<% @merchant_items.each do |item| %>
+  <img src="<%= item.image %>" class="item-image">
+  <h3><%= item.name %></h3>
+  <p>Price: <%= "$#{item.price}" %></p>
+  <p>Status: <%= item.status %></p>
+  <p>Inventory: <%= item.inventory %></p>
+  <p>Merchant: <%= link_to "#{item.merchant.name}", "/merchants/#{item.merchant.id}"%></p>
+<% end %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -4,5 +4,7 @@
 <p>State: <%=  @merchant.state%></p>
 <p>Zip Code: <%=  @merchant.zip%></p>
 <br/>
+<%= link_to 'Items', "/merchants/#{@merchant.id}/items" %>
+<br/>
 <%= link_to 'Edit Merchant Info', "/merchants/#{@merchant.id}/edit" %>
 <%= link_to 'Delete Merchant', "/merchants/#{@merchant.id}", method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get '/merchants/:id/edit', to: 'merchants#edit'
   patch '/merchants/:id', to: 'merchants#update'
   delete '/merchants/:id', to: 'merchants#destroy'
+  get '/merchants/:merchant_id/items', to: 'merchants#items'
 
   get '/items', to: 'items#index'
 end

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -22,7 +22,10 @@ describe 'When user visits items index page' do
 
     expect(page).to have_content('Bushy Brush')
     expect(page).to have_content('A lovely bushy brush for brushing bushes.')
+    expect(page).to have_link('Bob Ross Paints')
+
     expect(page).to have_content('Chocolate Crunchy Taco Chips')
     expect(page).to have_content('Crunchy corn chips with dark chocolate and chili powder!')
+    expect(page).to have_link('Yum Yum Snacks')
   end
 end

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 describe 'User clicks delete button on merchant show page' do
   it 'Destroys record of merchant' do
-    merchant_1 = Merchant.create!(name: 'Bob Ross Paints',
+    Item.destroy_all
+    Merchant.destroy_all
+    merchant_1 = Merchant.create(name: 'Bob Ross Paints',
                                 address: '2345 Happy Tree Place',
                                 city: 'Boulder',
                                 state: 'CO',

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 describe 'User clicks delete button on merchant show page' do
   it 'Destroys record of merchant' do
-    Item.destroy_all
-    Merchant.destroy_all
     merchant_1 = Merchant.create(name: 'Bob Ross Paints',
                                 address: '2345 Happy Tree Place',
                                 city: 'Boulder',

--- a/spec/features/merchants/items_spec.rb
+++ b/spec/features/merchants/items_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'User clicks ITEMS link on merchant show page' do
+  it 'Brings user to page with items belonging to that merchant' do
+    bob = Merchant.create( name: 'Bob Ross Paints', address: '2345 Happy Tree Place', city: 'Boulder', state: 'CO', zip: '80303')
+    brush = bob.items.create( name: 'Bushy Brush',
+                      description: 'A lovely bushy brush for brushing bushes.',
+                      price: 12.99,
+                      image: 'http://www.asianbrushpainter.com/media/catalog/product/cache/1/thumbnail/9df78eab33525d08d6e5fb8d27136e95/h/a/happiness-highland-bull-horn-brush-black-goat-hair-1_27.jpg',
+                      active: true,
+                      inventory: 32)
+
+    paint = bob.items.create( name: 'Starter Paint Set',
+                      description: '24 beautiful natural colors for you to blend and stroke to your hearts content',
+                      price: 37.99,
+                      image: 'https://cdn.dick-blick.com/items/016/37/01637-0249-5-1-2ww-m.jpg',
+                      active: true,
+                      inventory: 17)
+
+    visit "merchants/#{bob.id}/items"
+
+    expect(page).to have_content(brush.name)
+    expect(page).to have_content(brush.price)
+    # expect(page).to have_content(brush.image)
+    expect(page).to have_content(brush.status)
+    expect(page).to have_content(brush.inventory)
+
+    expect(page).to have_content(paint.name)
+    expect(page).to have_content(paint.price)
+    # expect(page).to have_content(paint.image)
+    expect(page).to have_content(paint.status)
+    expect(page).to have_content(paint.inventory)
+  end
+end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 describe 'user views one merchant,' do
   describe 'they click on the merchant link,' do
     it 'displays that merchant info' do
-      Item.destroy_all
-      Merchant.destroy_all
       merchant = Merchant.create( name: 'Bob Ross Paints',
                                   address: '2345 Happy Tree Place',
                                   city: 'Boulder',

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -19,6 +19,7 @@ describe 'user views one merchant,' do
       expect(page).to have_content("City: #{merchant.city}")
       expect(page).to have_content("State: #{merchant.state}")
       expect(page).to have_content("Zip Code: #{merchant.zip}")
+      expect(page).to have_link("Items")
       expect(page).to have_link("Edit Merchant Info")
     end
   end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe 'user views one merchant,' do
   describe 'they click on the merchant link,' do
     it 'displays that merchant info' do
+      Item.destroy_all
+      Merchant.destroy_all
       merchant = Merchant.create( name: 'Bob Ross Paints',
                                   address: '2345 Happy Tree Place',
                                   city: 'Boulder',


### PR DESCRIPTION
When a user visits '/merchants/:merchant_id/items'
Then they see each Item that belongs to the Merchant with that merchant_id including the Item's:
- name
- price
- image
- active/inactive status
- inventory