### PR TITLE
'Item Show' functionality implemented

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -26,6 +26,10 @@
    width: 400px;
  }
 
+ .solo-item {
+   align-items: center;
+ }
+
  .item-listing {
    display: inline;
  }
@@ -33,7 +37,7 @@
  header {
    background-color: DodgerBlue;
    margin: 0px;
-   padding: 20px 300px 20px 20px;
+   padding: 20px 25% 20px 20px;
    display: flex;
    justify-content: space-between;
  }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,18 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all
+    if params[:merchant_id]
+      @merchant = Merchant.find(params[:merchant_id])
+      @items = @merchant.items
+      @show = true
+    elsif params[:id]
+      @items = [ Item.find(params[:id]) ]
+    else
+      @items = Item.all
+      @show = true
+    end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -30,11 +30,6 @@ class MerchantsController < ApplicationController
     redirect_to '/merchants'
   end
 
-  def items
-    merchant = Merchant.find(params[:merchant_id])
-    @merchant_items = merchant.items
-  end
-
   private
 
   def merchant_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -2,10 +2,14 @@
 <% @items.each do |item| %>
     <img src="<%= item.image %>" class="item-image">
     <h3><%= item.name %></h3>
-    <p>Description: <%= item.description %></p>
+    <% if @merchant.nil? %>
+      <p>Description: <%= item.description %></p>
+    <% end %>
     <p>Price: <%= "$#{item.price}" %></p>
     <p>Status: <%= item.status %></p>
     <p>Inventory: <%= item.inventory %></p>
     <p>Merchant: <%= link_to "#{item.merchant.name}", "/merchants/#{item.merchant.id}"%></p>
-    <p><%= link_to 'View Item', "/items/#{item.id}" %></p>
+    <% if @show %>
+      <p><%= link_to 'View Item', "/items/#{item.id}" %></p>
+    <% end %>
 <% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -7,4 +7,5 @@
     <p>Status: <%= item.status %></p>
     <p>Inventory: <%= item.inventory %></p>
     <p>Merchant: <%= link_to "#{item.merchant.name}", "/merchants/#{item.merchant.id}"%></p>
+    <p><%= link_to 'View Item', "/items/#{item.id}" %></p>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,8 @@
   <body>
     <header>
       <span id="title">Fenton's Mini Shop</span>
-      <a href="#" class="header-link">Merchants</a>
-      <a href="#" class="header-link">Items</a>
+      <a href="/merchants" class="header-link">Merchants</a>
+      <a href="/items" class="header-link">Items</a>
     </header>
     <%= yield %>
   </body>

--- a/app/views/merchants/items.html.erb
+++ b/app/views/merchants/items.html.erb
@@ -1,8 +1,0 @@
-<% @merchant_items.each do |item| %>
-  <img src="<%= item.image %>" class="item-image">
-  <h3><%= item.name %></h3>
-  <p>Price: <%= "$#{item.price}" %></p>
-  <p>Status: <%= item.status %></p>
-  <p>Inventory: <%= item.inventory %></p>
-  <p>Merchant: <%= link_to "#{item.merchant.name}", "/merchants/#{item.merchant.id}"%></p>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,8 @@ Rails.application.routes.draw do
   get '/merchants/:id/edit', to: 'merchants#edit'
   patch '/merchants/:id', to: 'merchants#update'
   delete '/merchants/:id', to: 'merchants#destroy'
-  get '/merchants/:merchant_id/items', to: 'merchants#items'
+  get '/merchants/:merchant_id/items', to: 'items#index'
 
   get '/items', to: 'items#index'
+  get '/items/:id', to: 'items#index'
 end

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -4,14 +4,14 @@ describe 'When user visits items index page' do
   it 'Should show a list of all the items in the shop' do
     bob = Merchant.create( name: 'Bob Ross Paints', address: '2345 Happy Tree Place', city: 'Boulder', state: 'CO', zip: '80303')
     yum = Merchant.create( name: 'Yum Yum Snacks', address: '123 Tasty Town Ave', city: 'Denver', state: 'CO', zip: '80239')
-    bob.items.create( name: 'Bushy Brush',
+    brush = bob.items.create( name: 'Bushy Brush',
                       description: 'A lovely bushy brush for brushing bushes.',
                       price: 12.99,
                       image: 'http://www.asianbrushpainter.com/media/catalog/product/cache/1/thumbnail/9df78eab33525d08d6e5fb8d27136e95/h/a/happiness-highland-bull-horn-brush-black-goat-hair-1_27.jpg',
                       active: true,
                       inventory: 32)
 
-    yum.items.create( name: 'Chocolate Crunchy Taco Chips',
+    snack = yum.items.create( name: 'Chocolate Crunchy Taco Chips',
                       description: 'Crunchy corn chips with dark chocolate and chili powder!',
                       price: 3.79,
                       image: 'https://www.abdallahcandies.com/wp-content/uploads/2017/11/CHOC-COV-POTATO-CHIPS.png',
@@ -20,12 +20,20 @@ describe 'When user visits items index page' do
 
     visit '/items'
 
-    expect(page).to have_content('Bushy Brush')
-    expect(page).to have_content('A lovely bushy brush for brushing bushes.')
+    expect(page).to have_content(brush.name)
+    expect(page).to have_content(brush.description)
+    expect(page).to have_content(brush.price)
+    expect(page).to have_content(brush.status)
+    expect(page).to have_content(brush.inventory)
     expect(page).to have_link('Bob Ross Paints')
+    expect(page).to have_link('View Item')
 
-    expect(page).to have_content('Chocolate Crunchy Taco Chips')
-    expect(page).to have_content('Crunchy corn chips with dark chocolate and chili powder!')
+    expect(page).to have_content(snack.name)
+    expect(page).to have_content(snack.description)
+    expect(page).to have_content(snack.price)
+    expect(page).to have_content(snack.status)
+    expect(page).to have_content(snack.inventory)
     expect(page).to have_link('Yum Yum Snacks')
+    expect(page).to have_link('View Item')
   end
 end

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'User clicks View Item on items index' do
+  it 'Shows the info for that item' do
+    bob = Merchant.create( name: 'Bob Ross Paints', address: '2345 Happy Tree Place', city: 'Boulder', state: 'CO', zip: '80303')
+    brush = bob.items.create( name: 'Bushy Brush',
+                      description: 'A lovely bushy brush for brushing bushes.',
+                      price: 12.99,
+                      image: 'http://www.asianbrushpainter.com/media/catalog/product/cache/1/thumbnail/9df78eab33525d08d6e5fb8d27136e95/h/a/happiness-highland-bull-horn-brush-black-goat-hair-1_27.jpg',
+                      active: true,
+                      inventory: 32)
+
+    visit '/items'
+    click_link 'View Item'
+
+    expect(current_path).to eq("/items/#{brush.id}")
+
+    expect(page).to have_content(brush.name)
+    expect(page).to have_content(brush.description)
+    expect(page).to have_content(brush.price)
+    expect(page).to have_content(brush.status)
+    expect(page).to have_content(brush.inventory)
+    expect(page).to have_link('Bob Ross Paints')
+  end
+end


### PR DESCRIPTION
When a user visits '/items/:id'
Then they see the item with that id including the item's:
- name
- active/inactive status
- price
- description
- image
- inventory
- the name of the merchant that sells the item


Routes items, items/id, merchants/id/items, all through items index