### PR TITLE
Make all item names as links to that items show page

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -7,7 +7,7 @@
 
 <% @items.each do |item| %>
     <img src="<%= item.image %>" class="item-image">
-    <h3><%= item.name %></h3>
+    <h3><%= link_to item.name, "/items/#{item.id}", value: 'View Item' %></h3>
     <% if @merchant.nil? %>
       <p>Description: <%= item.description %></p>
     <% end %>
@@ -15,5 +15,4 @@
     <p>Status: <%= item.status %></p>
     <p>Inventory: <%= item.inventory %></p>
     <p>Merchant: <%= link_to "#{item.merchant.name}", "/merchants/#{item.merchant.id}"%></p>
-    <p><%= link_to 'View Item', "/items/#{item.id}" %></p>
 <% end %>

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -26,7 +26,6 @@ describe 'When user visits items index page' do
     expect(page).to have_content(brush.status)
     expect(page).to have_content(brush.inventory)
     expect(page).to have_link('Bob Ross Paints')
-    expect(page).to have_link('View Item')
 
     expect(page).to have_content(snack.name)
     expect(page).to have_content(snack.description)
@@ -34,6 +33,5 @@ describe 'When user visits items index page' do
     expect(page).to have_content(snack.status)
     expect(page).to have_content(snack.inventory)
     expect(page).to have_link('Yum Yum Snacks')
-    expect(page).to have_link('View Item')
   end
 end

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -10,10 +10,7 @@ describe 'User clicks View Item on items index' do
                       active: true,
                       inventory: 32)
 
-    visit '/items'
-    click_link 'View Item'
-
-    expect(current_path).to eq("/items/#{brush.id}")
+    visit "/items/#{brush.id}"
 
     expect(page).to have_content(brush.name)
     expect(page).to have_content(brush.description)


### PR DESCRIPTION
All item names on index and merchant items are now links to that item's show page